### PR TITLE
Added sub field to claimset struct

### DIFF
--- a/claimset.go
+++ b/claimset.go
@@ -13,4 +13,5 @@ type ClaimSet struct {
 	GivenName     string `json:"given_name"`
 	FamilyName    string `json:"family_name"`
 	Locale        string `json:"locale"`
+	Subject       string `json:"sub"`
 }

--- a/claimset.go
+++ b/claimset.go
@@ -13,5 +13,5 @@ type ClaimSet struct {
 	GivenName     string `json:"given_name"`
 	FamilyName    string `json:"family_name"`
 	Locale        string `json:"locale"`
-	Subject       string `json:"sub"`
+	HostedDomain  string `json:"hd, omitempty"`
 }


### PR DESCRIPTION
Was working with this library and noticed that the decoded token struct didn't contain the subject ID. Since this sub doesn't change, it's a better identifier than email.