### PR TITLE
Add the Hosted Domain ("hd") claim, for gsuite users

### DIFF
--- a/claimset.go
+++ b/claimset.go
@@ -13,4 +13,6 @@ type ClaimSet struct {
 	GivenName     string `json:"given_name"`
 	FamilyName    string `json:"family_name"`
 	Locale        string `json:"locale"`
+	// Hd is the hosted domain, present if the user is in a Gsuite domain.
+	Hd  string `json:"hd,omitempty"`
 }


### PR DESCRIPTION
Adds an additional, optional claim: "hd". This is the "hosted domain", the domain name of a google apps/gsuite user.

Useful if one is trying to create a Google-auth'd app for internal use at a company.

~~

Thanks so much for making this library, it's really useful and I'm glad to not have to make a network request to verify the JWT. No pressure to accept this PR, I'm happy to use my fork instead :) 